### PR TITLE
Fixes faceted searches that begin in subjects table

### DIFF
--- a/app/components/acfa/control_access_table_component.html.erb
+++ b/app/components/acfa/control_access_table_component.html.erb
@@ -1,6 +1,6 @@
 <table class="subjectTable">
-  <%= render Acfa::ControlAccess::FieldRowsComponent.new(field_name: 'subject', label: 'Genre/Form', terms: @genres_forms, print_view: @print_view) %>
+  <%= render Acfa::ControlAccess::FieldRowsComponent.new(field_name: 'subjects', label: 'Genre/Form', terms: @genres_forms, print_view: @print_view) %>
   <%= render Acfa::ControlAccess::FieldRowsComponent.new(field_name: 'names', label: 'Name', terms: @name_terms, print_view: @print_view) %>
-  <%= render Acfa::ControlAccess::FieldRowsComponent.new(field_name: 'place', label: 'Place', terms: @place_terms, print_view: @print_view) %>
-  <%= render Acfa::ControlAccess::FieldRowsComponent.new(field_name: 'subject', label: 'Subject', terms: @subjects, print_view: @print_view) %>
+  <%= render Acfa::ControlAccess::FieldRowsComponent.new(field_name: 'places', label: 'Place', terms: @place_terms, print_view: @print_view) %>
+  <%= render Acfa::ControlAccess::FieldRowsComponent.new(field_name: 'subjects', label: 'Subject', terms: @subjects, print_view: @print_view) %>
 </table>


### PR DESCRIPTION
Links in the subject tables create a faceted search based on the field name. Only the "names" searches were correctly applying a facet, because the field names "subject" and "place" were not plural, and therefore not matching the facet name.