### PR TITLE
Add API endpoints for indexing, deleting collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ blacklight.yml
 credentials.yml.enc
 database.yml
 finding_aids.yml
+index_api.yml
 master.key
 redis.yml
 repositories.yml

--- a/app/controllers/api/v1/index_controller.rb
+++ b/app/controllers/api/v1/index_controller.rb
@@ -19,7 +19,7 @@ module Api
         if indexed.positive?
           Acfa::Index.build_suggester(solr_url)
         else
-          Rails.logger.debug "no files indexed at #{glob_pattern}"
+          Rails.logger.debug "no files indexed for bibids: #{bibids.join(', ')}"
         end
         render plain: "Success!"
       end

--- a/app/controllers/api/v1/index_controller.rb
+++ b/app/controllers/api/v1/index_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'acfa/index'
+
+module Api
+  module V1
+    class IndexController < ApiController
+      before_action :authenticate_request_token
+
+      def index_ead
+        bibids = params[:bibids]
+        solr_url = ENV.fetch('SOLR_URL', Blacklight.default_index.connection.base_uri)
+        indexed = 0
+        bibids.each do |bibid|
+          filename = "as_ead_#{bibid}.xml"
+          indexing_job = IndexEadJob.new
+          indexed += indexing_job.perform(filename)
+        end
+        if indexed.positive?
+          Acfa::Index.build_suggester(solr_url)
+        else
+          Rails.logger.debug "no files indexed at #{glob_pattern}"
+        end
+        render plain: "Success!"
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/index_controller.rb
+++ b/app/controllers/api/v1/index_controller.rb
@@ -23,6 +23,23 @@ module Api
         end
         render plain: "Success!"
       end
+      
+      def delete_ead
+        bibids = params[:bibids]
+        solr_url = ENV.fetch('SOLR_URL', Blacklight.default_index.connection.base_uri)
+        deleted = 0
+        bibids.each do |bibid|
+          delete_job = DeleteEadJob.new
+          deleted += delete_job.perform(bibid)
+        end
+        if deleted.positive?
+          Acfa::Index.build_suggester(solr_url)
+        else
+          Rails.logger.debug "no bibids deleted"
+        end
+        render plain: "Success!"
+      end
+      
     end
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ApiController < ActionController::API
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+  
+  def authenticate_request_token
+    authenticate_or_request_with_http_token do |token, _options|
+      ActiveSupport::SecurityUtils.secure_compare(INDEX_API['remote_request_api_key'], token)
+      end
+    end
+
+
+end

--- a/app/jobs/delete_ead_job.rb
+++ b/app/jobs/delete_ead_job.rb
@@ -6,7 +6,6 @@ class DeleteEadJob < ApplicationJob
     solr_con.commit(softCommit: true)
     solr_url = solr_con.base_uri
     `curl #{solr_url}suggest?suggest.build=true`
-    puts solr_response.inspect
     1
   end
   

--- a/app/jobs/delete_ead_job.rb
+++ b/app/jobs/delete_ead_job.rb
@@ -1,12 +1,10 @@
 class DeleteEadJob < ApplicationJob
-  
   def perform(bibid)
     solr_con = Blacklight.default_index.connection
-    solr_response = solr_con.delete_by_query "_root_:#{bibid}"
+    solr_con.delete_by_query "_root_:#{bibid}"
     solr_con.commit(softCommit: true)
     solr_url = solr_con.base_uri
-    `curl #{solr_url}suggest?suggest.build=true`
+    Acfa::Index.build_suggester(solr_url)
     1
   end
-  
 end

--- a/app/jobs/delete_ead_job.rb
+++ b/app/jobs/delete_ead_job.rb
@@ -1,0 +1,13 @@
+class DeleteEadJob < ApplicationJob
+  
+  def perform(bibid)
+    solr_con = Blacklight.default_index.connection
+    solr_response = solr_con.delete_by_query "_root_:#{bibid}"
+    solr_con.commit(softCommit: true)
+    solr_url = solr_con.base_uri
+    `curl #{solr_url}suggest?suggest.build=true`
+    puts solr_response.inspect
+    1
+  end
+  
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -47,6 +47,7 @@ set :linked_files, fetch(:linked_files, []).push(
   'config/blacklight.yml',
   'config/database.yml',
   'config/finding_aids.yml',
+  'config/index_api.yml',
   'config/master.key',
   'config/redis.yml',
   'config/repositories.yml',

--- a/config/initializers/index_api.rb
+++ b/config/initializers/index_api.rb
@@ -1,0 +1,1 @@
+INDEX_API = Rails.application.config_for(:index_api)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
   namespace :api do
       namespace :v1, defaults: { format: :json } do
         post '/index/index_ead', to: 'index#index_ead'
+        post '/index/delete_ead', to: 'index#delete_ead'
       end
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,4 +47,9 @@ Rails.application.routes.draw do
     get 'redirectnonshib'
   end
   root 'repositories#index'
+  namespace :api do
+      namespace :v1, defaults: { format: :json } do
+        post '/index/index_ead', to: 'index#index_ead'
+      end
+    end
 end

--- a/config/templates/index_api.template.yml
+++ b/config/templates/index_api.template.yml
@@ -1,0 +1,5 @@
+development:
+  remote_request_api_key: example-development-key
+
+test:
+  remote_request_api_key: example-test-key

--- a/lib/acfa/index.rb
+++ b/lib/acfa/index.rb
@@ -1,0 +1,5 @@
+module Acfa::Index
+  def self.build_suggester(solr_url)
+    `curl #{solr_url}suggest?suggest.build=true`
+  end
+end

--- a/lib/tasks/acfa.rake
+++ b/lib/tasks/acfa.rake
@@ -48,7 +48,7 @@ namespace :acfa do
     solr_response = solr_con.delete_by_query "_root_:#{ENV['COLLECTION']}"
     solr_con.commit(softCommit: true)
     solr_url = solr_con.base_uri
-    Acfa::Index.build_suggester(solr_url)
+    `curl #{solr_url}suggest?suggest.build=true`
     puts solr_response.inspect
   end
 end

--- a/lib/tasks/acfa.rake
+++ b/lib/tasks/acfa.rake
@@ -48,7 +48,7 @@ namespace :acfa do
     solr_response = solr_con.delete_by_query "_root_:#{ENV['COLLECTION']}"
     solr_con.commit(softCommit: true)
     solr_url = solr_con.base_uri
-    `curl #{solr_url}suggest?suggest.build=true`
+    Acfa::Index.build_suggester(solr_url)
     puts solr_response.inspect
   end
 end

--- a/spec/acfa/index_spec.rb
+++ b/spec/acfa/index_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+require 'acfa/index.rb'
+
+RSpec.describe Acfa::Index do
+  describe ".build_suggester" do
+    let(:example_solr_url) { 'https://example.com:12345' }
+    it "works as expected" do
+      expect(described_class).to receive(:`).with("curl #{example_solr_url}suggest?suggest.build=true")
+      described_class.build_suggester(example_solr_url)
+    end
+  end
+end

--- a/spec/jobs/delete_ead_job_spec.rb
+++ b/spec/jobs/delete_ead_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe DeleteEadJob do
+  let(:delete_ead_job) { described_class.new }
+  let(:bibid) { 123456789 }
+  let(:solr_con) { Blacklight.default_index.connection }
+
+  describe '#perform' do
+    it 'deletes the given bibid record from the solr index, builds a suggester, and returns the expected value' do
+      expect(solr_con).to receive(:delete_by_query).with("_root_:#{bibid}")
+      expect(solr_con).to receive(:commit).with(softCommit: true)
+      expect(Acfa::Index).to receive(:build_suggester).and_call_original
+      expect(delete_ead_job.perform(bibid)).to eq(1)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  
+  # Include helpers
+  config.include AuthenticatedRequests, type: :request
 end

--- a/spec/requests/api/v1/index/delete_ead_spec.rb
+++ b/spec/requests/api/v1/index/delete_ead_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+require 'acfa/index.rb'
+
+
+url = "/api/v1/index/delete_ead"
+
+RSpec.describe url, type: :request do
+  describe "without authentication" do
+    it "returns the expected response" do
+      post url
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "with authentication" do
+    let(:bibids) { ['ldpd_7746709', 'ldpd_8972723'] }
+    let(:delete_ead_job_double) { double(DeleteEadJob) }
+    before do
+      allow(DeleteEadJob).to receive(:new).and_return(delete_ead_job_double)
+      bibids.each do |bibid|
+        expect(delete_ead_job_double).to receive(:perform).with(bibid).and_return(1)
+      end
+      allow(Acfa::Index).to receive(:build_suggester)
+    end
+    it "returns the expected response" do
+      post_with_auth  url,
+                      headers: { 'Content-Type' => 'application/json' },
+                      params: {"bibids" => bibids}.to_json
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/api/v1/index/index_ead_spec.rb
+++ b/spec/requests/api/v1/index/index_ead_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+require 'acfa/index.rb'
+
+
+url = "/api/v1/index/index_ead"
+
+RSpec.describe url, type: :request do
+  describe "without authentication" do
+    it "returns the expected response" do
+      post url
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "with authentication" do
+    let(:bibids) { ['ldpd_7746709', 'ldpd_8972723'] }
+    let(:index_ead_job_double) { double(IndexEadJob) }
+    before do
+      allow(IndexEadJob).to receive(:new).and_return(index_ead_job_double)
+      bibids.each do |bibid|
+        expect(index_ead_job_double).to receive(:perform).with("as_ead_#{bibid}.xml").and_return(1)
+      end
+      allow(Acfa::Index).to receive(:build_suggester)
+    end
+    it "returns the expected response" do
+      post_with_auth  url,
+                      headers: { 'Content-Type' => 'application/json' },
+                      params: {"bibids" => bibids}.to_json
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,15 +62,16 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
   # aliases for `it`, `describe`, and `context` that include `:focus`
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
+
+  # The settings below are suggested to provide a good initial experience
+# with RSpec, but feel free to customize to your heart's content.
+=begin
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend

--- a/spec/support/authenticated_requests.rb
+++ b/spec/support/authenticated_requests.rb
@@ -1,0 +1,13 @@
+module AuthenticatedRequests
+  # Generates custom http request methods that end in `_with_auth`. These methods
+  # add authentication to each request.
+  [:post].each do |http_method|
+    define_method "#{http_method}_with_auth" do |path, **args|
+      args[:headers] = args.fetch(:headers, {}).merge(
+        'Authorization' => "Token #{INDEX_API['remote_request_api_key']}"
+      )
+
+      send(http_method, path, **args)
+    end
+  end
+end


### PR DESCRIPTION
Fixes ACFA-492 + includes API endpoint that was already merged into v1.x.

@elohanlon and @nwalker2398 -- would appreciate either of your review as we word on the first part of this together. In particular, I'm not sure if I should have a set up/teardown method on the test for the deletion endpoint.