### PR TITLE
symlink to sitemap in shared directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ node_modules
 # https://vitejs.dev/guide/env-and-mode.html#env-files
 *.local
 
+
+/public/sitemaps/sitemap*.xml.gz

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,10 +30,11 @@ append  :linked_files,
         'config/redis.yml',
         'config/repositories.yml',
         'config/resque.yml',
-        'config/secrets.yml'
+        'config/secrets.yml',
+        'public/robots.txt'
 
 # Default value for linked_dirs is []
-append :linked_dirs, 'log', 'tmp/pids', 'node_modules'
+append :linked_dirs, 'log', 'tmp/pids', 'node_modules', 'public/sitemaps'
 
 set :passenger_restart_with_touch, true
 

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -3,6 +3,7 @@ host = Rails.application.config.default_host
 SitemapGenerator::Sitemap.default_host = host
 Rails.application.routes.default_url_options[:host] = host
 
+SitemapGenerator::Sitemap.sitemaps_path = 'sitemaps'
 SitemapGenerator::Sitemap.create do
   # The root path '/' and sitemap index file are added automatically for you.
   # Links are added to the Sitemap in the order they are specified.


### PR DESCRIPTION
These changes will move the sitemap to the server's shared directory so that it will available immediately after deploys.
I'm documenting here the one-time steps that will need to be taken on the server so that the shared sitemap is discoverable:

-confirm robots.txt is in shared/public/ (or copy it there from current/public/)
-create shared/public/sitemaps/ directory
-copy current/public/sitemap.xml.gz into shared/public/sitemaps/ directory
-edit shared/public/robots.txt to point to shared/public/sitemaps/sitemap.xml.gz
