### PR TITLE
apply the same logic to “drawer” as “mapcase”

### DIFF
--- a/app/values/aeon_local_request.rb
+++ b/app/values/aeon_local_request.rb
@@ -28,17 +28,21 @@ class AeonLocalRequest
   end
 
   def box_or_highest_requestable_level_label
-    # A mapcase itself is not requestable, so for mapcases we return the second-level container
-    # (which we are referring to here as the "highest requestable level") and we prefix it with "mapcase, "
+    # A mapcase or drawer itself is not requestable, so for mapcases we return the second-level container
+    # (which we are referring to here as the "highest requestable level") and we prefix it with the label,
     # so that the staff member processing this request knows that the secondary level is something
-    # within a mapcase.
-    if container_labels.length > 1 && container_labels.first.downcase.include?('mapcase')
+    # within a mapcase or drawer.
+    if container_labels.length > 1 && mapcase_or_drawer?(container_labels.first)
       # This is a mapcase and we should group one level below it
-      "mapcase, #{container_labels[1]}"
+      "#{container_labels.first}, #{container_labels[1]}"
     else
       # Otherwise we'll just use the top level container as the grouping field
       container_labels[0]
     end
+  end
+  
+  def mapcase_or_drawer?(label)
+    label.downcase.include?('mapcase') || label.downcase.include?('drawer')
   end
 
   def reference_number

--- a/spec/values/aeon_local_request_spec.rb
+++ b/spec/values/aeon_local_request_spec.rb
@@ -145,8 +145,8 @@ RSpec.describe AeonLocalRequest do
           }.to_json
         ]
       end
-      it 'returns the second level container, prefixed with "mapcase, "' do
-        expect(aeon_local_request.grouping_field_value).to eq('mapcase, folder 3')
+      it 'returns the second level container, prefixed with top container' do
+        expect(aeon_local_request.grouping_field_value).to eq('mapcase 15-J-8, folder 3')
       end
     end
 

--- a/spec/values/aeon_local_request_spec.rb
+++ b/spec/values/aeon_local_request_spec.rb
@@ -182,6 +182,20 @@ RSpec.describe AeonLocalRequest do
     end
   end
 
+  describe '#mapcase_or_drawer?' do
+    it 'returns true for mapcase' do
+      expect(aeon_local_request.mapcase_or_drawer?('mapcase 123')).to eq(true)
+    end
+
+    it 'returns true for drawer' do
+      expect(aeon_local_request.mapcase_or_drawer?('Drawer 456')).to eq(true)
+    end
+
+    it 'returns false for other labels' do
+      expect(aeon_local_request.mapcase_or_drawer?('box 789')).to eq(false)
+    end
+  end
+
   describe '#reference_number' do
     context "when the record id matches our expected bibid id pattern" do
       it 'extracts the bibid' do


### PR DESCRIPTION
- fixes ACFA-598
- also sends drawer/mapcase location to aeon