### PR TITLE
ACFA-628 Update "has_fa_list" to "exclude_from_home"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ '*' ]
+    branches: 
+      - '**'
 
 jobs:
   ci-rails-app:

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -1,6 +1,6 @@
 class RepositoriesController < Arclight::RepositoriesController
   def index
-    @repositories = Arclight::Repository.all.select { |repo| repo.has_fa_list? }
+    @repositories = Arclight::Repository.all.reject { |repo| repo.exclude_from_home? }
     load_collection_counts
   end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -12,7 +12,7 @@ class Repository
   DEFAULTS = {
     name: '',
     url: '',
-    has_fa_list: false,
+    exclude_from_home: false,
     as_repo_id: nil,
     request_types: {},
     contact_html: '',
@@ -41,8 +41,8 @@ class Repository
     request_types.fetch(type, {})
   end
 
-  def has_fa_list?
-    @attributes[:has_fa_list]
+  def exclude_from_home?
+    @attributes[:exclude_from_home]
   end
 
   def as_repo_id

--- a/app/overrides/arclight/repository_override.rb
+++ b/app/overrides/arclight/repository_override.rb
@@ -14,8 +14,8 @@ Arclight::Repository.class_eval do
   end
 
   # local method
-  def has_fa_list?
-    @attributes[:has_fa_list]
+  def exclude_from_home?
+    @attributes[:exclude_from_home]
   end
 
   # local method

--- a/config/templates/repositories.template.yml
+++ b/config/templates/repositories.template.yml
@@ -28,9 +28,8 @@ base: &BASE
     # url is the desired url to be used for the library link at the top of a
     # finding aids page
     url: https://library.columbia.edu
-    # has_fa_list indicates whether or not a repo has an entry in the
-    # home/main/landingpage for the findingaids app
-    has_fa_list: false
+    # exclude_from_home indicates whether a repository should be displayed on the homepage
+    exclude_from_home: true
     contact:
       phone: '212-854-7309'
       email: lio@columbia.edu
@@ -72,7 +71,7 @@ base: &BASE
     as_repo_id: 3
     name: 'Avery Drawings & Archives Collections'
     url: https://findingaids.library.columbia.edu/ead/nnc-a
-    has_fa_list: true
+    exclude_from_home: false
     contact:
       email: avery@library.columbia.edu
       links:
@@ -100,7 +99,7 @@ base: &BASE
     as_repo_id: 2
     name: Oral History Archives at Columbia
     url: https://findingaids.library.columbia.edu/ead/nnc-ccoh
-    has_fa_list: true
+    exclude_from_home: false
     contact:
       email: oralhist@library.columbia.edu
       links:
@@ -130,7 +129,7 @@ base: &BASE
     as_repo_id: 4
     name: C.V. Starr East Asian Library
     url: https://findingaids.library.columbia.edu/ead/nnc-ea
-    has_fa_list: true
+    exclude_from_home: false
     contact:
       email: starr@library.columbia.edu
       links:
@@ -158,7 +157,7 @@ base: &BASE
     as_repo_id: 2
     name: Rare Book & Manuscript Library
     url: https://findingaids.library.columbia.edu/ead/nnc-rb
-    has_fa_list: true
+    exclude_from_home: false
     contact:
       email: rbml@library.columbia.edu
       links:
@@ -186,7 +185,7 @@ base: &BASE
     as_repo_id: 2
     name: Columbia University Archives
     url: https://findingaids.library.columbia.edu/ead/nnc-ua
-    has_fa_list: true
+    exclude_from_home: false
     contact:
       email: uarchives@columbia.edu
       links:
@@ -216,7 +215,7 @@ base: &BASE
     as_repo_id: 5
     name: Burke Library at Union Theological Seminary
     url: https://findingaids.library.columbia.edu/ead/nnc-ut
-    has_fa_list: true
+    exclude_from_home: false
     contact:
       email: burke@library.columbia.edu
       links:
@@ -239,7 +238,7 @@ base: &BASE
     as_repo_id: clio_only
     name: Health Sciences Library
     url: https://www.library-archives.cumc.columbia.edu/finding-aids
-    has_fa_list: false
+    exclude_from_home: true
     contact:
       email: hsl@example.org
       links:
@@ -264,7 +263,7 @@ base: &BASE
     as_repo_id: clio_only
     name: Oral History Archives at Columbia
     url: https://library.columbia.edu/locations/ccoh.html
-    has_fa_list: false
+    exclude_from_home: true
     contact:
       email: oralhist@library.columbia.edu
       links:
@@ -289,7 +288,7 @@ base: &BASE
     as_repo_id: clio_only
     name: Barnard Archives & Special Collections
     url: https://archives.barnard.edu/
-    has_fa_list: true
+    exclude_from_home: false
     contact:
       email: archives@barnard.edu
       links:

--- a/spec/fixtures/config/aspace_repositories.yml
+++ b/spec/fixtures/config/aspace_repositories.yml
@@ -6,7 +6,7 @@ test:
     as_repo_id: 2
     name: The Library
     url: https://library.edu/collections
-    has_fa_list: true
+    exclude_from_home: false
     contact:
       email: rbml@library.columbia.edu
       links:

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -29,9 +29,9 @@ describe Repository, type: :model do
   end
 
 
-  describe '#has_fa_list?' do
+  describe '#exclude_from_home?' do
     it "returns configured value" do
-      expect(repository.has_fa_list?).to be true
+      expect(repository.exclude_from_home?).to be false
     end
   end
 


### PR DESCRIPTION
# Ticket [ACFA-628](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-628)

## Overview
1. Renamed `has_fa_list?` method to `exclude_from_home?` and `has_fa_list` field to `exclude_from_home`
2. Updated the default behavior to show a repository on the homepage
3. Updated templates and tests