### PR TITLE
ACFA-632 Fix aggressive search stemming

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -141,7 +141,7 @@
         <tokenizer class="solr.ICUTokenizerFactory" />
         <filter class="solr.KeywordRepeatFilterFactory" />
         <filter class="solr.ICUFoldingFilterFactory" />
-        <filter class="solr.PorterStemFilterFactory"/>
+        <filter class="solr.EnglishMinimalStemFilterFactory" />
         <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
       </analyzer>
     </fieldType>
@@ -155,7 +155,7 @@
         <filter class="solr.EnglishPossessiveFilterFactory"/>
         <filter class="solr.ICUFoldingFilterFactory" />
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.PorterStemFilterFactory"/>
+        <filter class="solr.EnglishMinimalStemFilterFactory" />
         <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
         <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
       </analyzer>
@@ -167,7 +167,7 @@
         <filter class="solr.ICUFoldingFilterFactory" />
         <filter class="solr.EnglishPossessiveFilterFactory"/>
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.PorterStemFilterFactory"/>
+        <filter class="solr.EnglishMinimalStemFilterFactory" />
         <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
       </analyzer>
     </fieldType>


### PR DESCRIPTION
# Ticket [ACFA-632](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-632)

Fixes aggressive search stemming by using the `EnglishMinimalStemFilterFactory` filter. Examples below.

### "Oriental" and "orientation"

Production: "Oriental" matches "orientation"
<img width="1446" height="1163" alt="Screenshot 2025-07-24 at 3 46 06 PM" src="https://github.com/user-attachments/assets/6c8a0b2e-dcc6-4067-b23f-1082759764f7" />

New changes: "Oriental" doesn't match "orientation"
<img width="1336" height="766" alt="Screenshot 2025-07-24 at 3 46 55 PM" src="https://github.com/user-attachments/assets/0af40299-3682-461a-a597-0bc9fb1c508b" />

New changes: "Orientation" also doesn't return results that include "oriental"
<img width="1345" height="1220" alt="Screenshot 2025-07-24 at 3 47 30 PM" src="https://github.com/user-attachments/assets/ef685afb-6d62-4736-b380-746e25ddd1bd" />

### "Organs" and "organization"
Production: Searching for "organs" matches "organization"
<img width="1387" height="1222" alt="Screenshot 2025-07-24 at 3 49 14 PM" src="https://github.com/user-attachments/assets/39dd1d36-2cf6-4073-878f-46416f467607" />

New changes: Searching for "organs" doesn't return matches for "organization"
<img width="1303" height="1217" alt="Screenshot 2025-07-24 at 3 49 59 PM" src="https://github.com/user-attachments/assets/b5c20d3f-063d-4c42-8552-0c4b709b921b" />

New changes: Searching for "organization" doesn't return matches for "organs"
<img width="1265" height="1220" alt="Screenshot 2025-07-24 at 3 51 13 PM" src="https://github.com/user-attachments/assets/541808a2-6122-423b-9b2c-f2b892db702c" />

