### PR TITLE
ACFA-610 Remove image from Access and Use

### DIFF
--- a/app/components/acfa/arclight/repository_location_field_component.html.erb
+++ b/app/components/acfa/arclight/repository_location_field_component.html.erb
@@ -4,12 +4,7 @@
   <% end %>
   <% component.with_value do %>
     <div class='al-in-person-repository-name'>
-      <% if repository.thumbnail_url %>
-        <%= image_tag repository.thumbnail_url, alt: '', class: 'img-fluid float-left' %>
-      <% end %>
-      <div>
-        <%= link_to(repository.name, arclight_engine.repository_path(repository.slug)) %>
-      </div>
+      <%= link_to(repository.name, arclight_engine.repository_path(repository.slug)) %>
     </div>
     <div class='al-in-person-repository-location'>
       <address>


### PR DESCRIPTION
# Ticket [ACFA-610](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-610)

## Changes
Removes the image from the "Access and Use" section. 

We still use the `thumbnail_url` value in other components so I didn't remove it from the config/repositories.yml. I listed other places where this value is used in the ticket.