### PR TITLE
ACFA-604 Fix extraneous "and" in the "extent" field

### DIFF
--- a/lib/ead/traject/ead2_component_config.rb
+++ b/lib/ead/traject/ead2_component_config.rb
@@ -133,7 +133,7 @@ end
 
 to_field 'extent_ssm' do |record, accumulator|
   # Add each physdesc separately to the accumulator
-  accumulator.concat(extents_per_physdesc(record.xpath('./did/physdesc')))
+  accumulator.concat(extents_per_physdesc(record.xpath('./did/physdesc[extent]')))
 end
 
 # include digital objects with multiple file versions

--- a/lib/ead/traject/ead2_config.rb
+++ b/lib/ead/traject/ead2_config.rb
@@ -151,7 +151,7 @@ to_field 'language_ssim', extract_xpath('/ead/archdesc/did/langmaterial/language
 
 to_field 'extent_ssm' do |record, accumulator|
   # Add each physdesc separately to the accumulator
-  accumulator.concat(extents_per_physdesc(record.xpath('/ead/archdesc/did/physdesc')))
+  accumulator.concat(extents_per_physdesc(record.xpath('/ead/archdesc/did/physdesc[extent]')))
 end
 
 to_field 'call_number_ss', extract_xpath('/ead/archdesc/did/unitid[translate(., "0123456789", "")][not(@type)]'), first_only


### PR DESCRIPTION
# Ticket [ACFA-604](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-604)

### Problem
When EAD documents contained multiple `<physdesc>` elements where some had `<extent>` children and others didn't (e.g., one with extents and another with only `<dimensions>`), the code was processing all `<physdesc>` elements and adding empty strings to the extent array for those without extents. 
This resulted in Arclight trying to join those elements using the default `separator_options` (which uses [Ruby's "to_sentence" method](https://apidock.com/rails/Array/to_sentence) which defaults to " and"), causing an extra "and" to appear in the UI.

### Fix
Changed the XPath selector to prefilter and only process `<physdesc>` elements that actually contain extents, eliminating empty strings from the results array.