### PR TITLE
ACFA-634 Dynamically render repositories in the footer

### DIFF
--- a/app/components/cul/footer/contact_component.html.erb
+++ b/app/components/cul/footer/contact_component.html.erb
@@ -7,13 +7,11 @@
 	</div>
 	<div class="col">
 		<ul class="list-unstyled">
-			<li><%= link_to_repository_location('nnc-a') %></li>
-			<li><%= link_to_repository_location('nnc-ea') %></li>
-			<li><%= link_to_repository_location('nnc-rb') %></li>
-			<li><%= link_to_repository_location('nnc-ua') %></li>
-			<li><%= link_to_repository_location('nynycoh') %></li>
-			<li><%= link_to_repository_location('nnc-ut') %></li>
-			<li><%= link_to_repository_location('nynybaw') %></li>
+			<% @repositories.each do |repository| %>
+				<% unless repository.exclude_from_home %>
+					<li><%= link_to_repository_location(repository.slug) %></li>
+				<% end %>
+			<% end %>
 			<li><%= link_to "Donate Books or Items", "https://library.columbia.edu/about/policies/gifts-policy.html" %></li>
 			<li><%= link_to "Suggestions & Feedback", "https://feedback.cul.columbia.edu/feedback_submission/lweb?submitted_from_page=https%3A%2F%2Ffindingaids.library.columbia.edu%2F" %></li>
 			<li><%= link_to "Report an E-Resource Problem", "https://library.columbia.edu/resolve/lweb0006" %></li>

--- a/app/components/cul/footer/contact_component.html.erb
+++ b/app/components/cul/footer/contact_component.html.erb
@@ -1,22 +1,22 @@
 <div class="row">
-	<div class="col">
-		<%= render Cul::Footer::Contact::LocationComponent.new(repository: @repository) %>
-	</div>
-	<div class="col">
-		<%= render Cul::Footer::Contact::InformationComponent.new(repository: @repository) %>
-	</div>
-	<div class="col">
-		<ul class="list-unstyled">
-			<% @repositories.each do |repository| %>
-				<% unless repository.exclude_from_home %>
-					<li><%= link_to_repository_location(repository.slug) %></li>
-				<% end %>
-			<% end %>
-			<li><%= link_to "Donate Books or Items", "https://library.columbia.edu/about/policies/gifts-policy.html" %></li>
-			<li><%= link_to "Suggestions & Feedback", "https://feedback.cul.columbia.edu/feedback_submission/lweb?submitted_from_page=https%3A%2F%2Ffindingaids.library.columbia.edu%2F" %></li>
-			<li><%= link_to "Report an E-Resource Problem", "https://library.columbia.edu/resolve/lweb0006" %></li>
-			<li><%= link_to "Policies", "https://library.columbia.edu/about/policies.html" %></li>
-			<li><%= link_to "Copyright", "https://www.columbia.edu/content/copyright" %></li>
-		</ul>
-	</div>
+  <div class="col">
+    <%= render Cul::Footer::Contact::LocationComponent.new(repository: @repository) %>
+  </div>
+  <div class="col">
+    <%= render Cul::Footer::Contact::InformationComponent.new(repository: @repository) %>
+  </div>
+  <div class="col">
+    <ul class="list-unstyled">
+      <% @repositories.each do |repository| %>
+        <% unless repository.exclude_from_home %>
+          <li><%= link_to_repository_location(repository.slug) %></li>
+        <% end %>
+      <% end %>
+      <li><%= link_to "Donate Books or Items", "https://library.columbia.edu/about/policies/gifts-policy.html" %></li>
+      <li><%= link_to "Suggestions & Feedback", "https://feedback.cul.columbia.edu/feedback_submission/lweb?submitted_from_page=https%3A%2F%2Ffindingaids.library.columbia.edu%2F" %></li>
+      <li><%= link_to "Report an E-Resource Problem", "https://library.columbia.edu/resolve/lweb0006" %></li>
+      <li><%= link_to "Policies", "https://library.columbia.edu/about/policies.html" %></li>
+      <li><%= link_to "Copyright", "https://www.columbia.edu/content/copyright" %></li>
+    </ul>
+  </div>
 </div>

--- a/app/components/cul/footer/contact_component.rb
+++ b/app/components/cul/footer/contact_component.rb
@@ -4,11 +4,9 @@ module Cul::Footer
   class ContactComponent < ViewComponent::Base
     delegate :link_to_repository_location, to: :helpers
 
-    def initialize(repository:)
-      @repository = repository
-    end
-    def contact_links
-      @repository.contact&.fetch('links', nil) || []
+    def initialize(repositories:, current_repository_slug: nil)
+      @repositories = repositories
+      @repository = repositories.find { |repo| repo.slug == current_repository_slug }
     end
   end
 end

--- a/app/components/cul/footer/contact_component.rb
+++ b/app/components/cul/footer/contact_component.rb
@@ -4,9 +4,9 @@ module Cul::Footer
   class ContactComponent < ViewComponent::Base
     delegate :link_to_repository_location, to: :helpers
 
-    def initialize(repositories:, current_repository_slug: nil)
-      @repositories = repositories
-      @repository = repositories.find { |repo| repo.slug == current_repository_slug }
+    def initialize(current_repository_slug:)
+      @repositories = Arclight::Repository.all
+      @repository = @repositories.find { |repo| repo.slug == current_repository_slug } || @repositories.first
     end
   end
 end

--- a/app/components/cul/footer_component.html.erb
+++ b/app/components/cul/footer_component.html.erb
@@ -1,6 +1,6 @@
 <section id="contact-footer" class="py-5 mt-5 mb-2">
   <footer class="container small">
-    <%= render Cul::Footer::ContactComponent.new(repositories: @repositories, current_repository_slug: @current_repository_slug) %>
+    <%= render Cul::Footer::ContactComponent.new(current_repository_slug: @current_repository_slug) %>
   </footer>
 </section>
 

--- a/app/components/cul/footer_component.html.erb
+++ b/app/components/cul/footer_component.html.erb
@@ -1,6 +1,6 @@
 <section id="contact-footer" class="py-5 mt-5 mb-2">
   <footer class="container small">
-    <%= render Cul::Footer::ContactComponent.new(repository: @repository) %>
+    <%= render Cul::Footer::ContactComponent.new(repositories: @repositories, current_repository_slug: @current_repository_slug) %>
   </footer>
 </section>
 

--- a/app/components/cul/footer_component.rb
+++ b/app/components/cul/footer_component.rb
@@ -2,9 +2,8 @@
 
 module Cul
   class FooterComponent < ViewComponent::Base
-    def initialize(repositories: Arclight::Repository.all, current_repository_slug: nil)
-      @repositories = repositories
-      @current_repository_slug = current_repository_slug || 'nnc'
+    def initialize(current_repository_slug: 'nnc')
+      @current_repository_slug = current_repository_slug
     end
   end
 end

--- a/app/components/cul/footer_component.rb
+++ b/app/components/cul/footer_component.rb
@@ -2,8 +2,9 @@
 
 module Cul
   class FooterComponent < ViewComponent::Base
-    def initialize(repository: Arclight::Repository.find_by(slug: 'nnc'))
-      @repository = repository
+    def initialize(repositories: Arclight::Repository.all, current_repository_slug: nil)
+      @repositories = repositories
+      @current_repository_slug = current_repository_slug || 'nnc'
     end
   end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,2 +1,2 @@
-<%= render Cul::FooterComponent.new(repository: Arclight::Repository.find_by(slug: @repository&.id || 'nnc')) %>
+<%= render Cul::FooterComponent.new(repositories: Arclight::Repository.all, current_repository_slug: @repository&.slug) %>
 <div id="request-cart-widget"></div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,2 +1,2 @@
-<%= render Cul::FooterComponent.new(repositories: Arclight::Repository.all, current_repository_slug: @repository&.slug) %>
+<%= render Cul::FooterComponent.new(current_repository_slug: @repository&.slug) %>
 <div id="request-cart-widget"></div>


### PR DESCRIPTION
# Ticket [ACFA-634](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-634)

## Changes
1. Dynamically render links to repositories instead of hardcoding them
2. Pass down the current repository slug instead of the whole object. We can later extract the current repository from the array of all repositories (avoids duplicating the data).
3. Default values are set in component classes instead of templates
4. Remove `contact_links` method since it's unused and we want to keep the rest of the links hardcoded for now.