### PR TITLE
ACFA-630 Enable html formatting in <unittitles>

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -69,7 +69,7 @@ class CatalogController < ApplicationController
     config.track_search_session.storage = false
     # solr field configuration for search results/index views
     config.index.partials = %i[arclight_index_default]
-    config.index.title_field = 'normalized_title_ssm'
+    config.index.title_field = 'normalized_title'
     config.index.display_type_field = 'level_ssm'
     config.index.document_component = Acfa::Arclight::SearchResultComponent
     config.index.group_component = Acfa::Document::GroupComponent
@@ -82,7 +82,7 @@ class CatalogController < ApplicationController
     config.index.document_actions << :request_action
 
     # solr field configuration for document/show views
-    # config.show.title_field = 'title_display'
+    config.show.title_field = 'normalized_title'
     config.show.document_component = Acfa::Arclight::DocumentComponent
     config.show.sidebar_component = Acfa::SidebarComponent
     config.show.breadcrumb_component = Acfa::Arclight::BreadcrumbsHierarchyComponent

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -4,18 +4,21 @@ module BlacklightHelper
   include Blacklight::BlacklightHelperBehavior
 
   # Override Blacklight helper to prevent session tracking external links
+  # and to use HTML-formatted titles from normalized_title method
   def link_to_document(doc, field_or_opts = nil, opts = { counter: nil })
     label = case field_or_opts
             when NilClass
-              document_presenter(doc).heading
+              # Use the SolrDocument's label which uses normalized_title
+              document_presenter(doc).label
             when Hash
               opts = field_or_opts
-              document_presenter(doc).heading
+              # Use the SolrDocument's label which uses normalized_title
+              document_presenter(doc).label
             else # String
               field_or_opts
             end
     doc_link = search_state.url_for_document(doc)
     link_html_opts = doc_link.is_a?(String) ? { target: '_blank', class: "external-link", rel: "noopener noreferrer" } : document_link_params(doc, opts)
-    link_to label, doc_link, link_html_opts
+    link_to label.html_safe, doc_link, link_html_opts
   end
 end

--- a/app/helpers/ead_format_helpers.rb
+++ b/app/helpers/ead_format_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module EadFormatHelpers
+  include Arclight::EadFormatHelpers
+
+  private
+
+  def format_render_attributes(node)
+    # Remove the type attribute as it isn't valid HTML.
+    # 
+    # This will be addressed in the upstream Arclight core:
+    # https://github.com/projectblacklight/arclight/pull/1605
+    node.remove_attribute('type')
+
+    # Call the original method from the included Arclight::EadFormatHelpers module
+    super
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -4,7 +4,6 @@
 class SolrDocument
   include Blacklight::Solr::Document
   include Arclight::SolrDocument
-
   include ActionView::Helpers::TextHelper
   include EadFormatHelpers
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -5,6 +5,9 @@ class SolrDocument
   include Blacklight::Solr::Document
   include Arclight::SolrDocument
 
+  include ActionView::Helpers::TextHelper
+  include EadFormatHelpers
+
   # self.unique_key = 'id'
 
   # DublinCore uses the semantic field mappings below to assemble an OAI-compliant Dublin Core document
@@ -29,6 +32,12 @@ class SolrDocument
   def repository
     first('repository_ssm') || collection&.first('repository_ssm') ||
     first('repository_ssim') || collection&.first('repository_ssim')
+  end
+
+  # Use normalized_title_html_ssm to get HTML rendering of title
+  def normalized_title
+    value = first('normalized_title_html_ssm').to_s
+    render_html_tags(value: value) if value.present?
   end
 
   def requestable?

--- a/lib/ead/traject/ead2_component_config.rb
+++ b/lib/ead/traject/ead2_component_config.rb
@@ -55,6 +55,14 @@ end
 to_field 'language_material_ssm', extract_xpath('./did/langmaterial')
 to_field 'language_ssim', extract_xpath('./did/langmaterial/language')
 
+to_field 'title_html_ssm', extract_xpath('./did/unittitle', to_text: false)
+
+to_field 'normalized_title_html_ssm'  do |_record, accumulator, context|
+  title = context.output_hash['title_html_ssm']&.first&.to_s
+  date = context.output_hash['normalized_date_ssm']&.first
+  accumulator << settings['title_normalizer'].constantize.new(title, date).to_s
+end
+
 to_field 'collection_sort' do |_rec, accumulator, _context|
   accumulator.concat((settings[:root].output_hash['normalized_title_ssm'] || []).slice(0,1))
 end

--- a/lib/ead/traject/ead2_component_config.rb
+++ b/lib/ead/traject/ead2_component_config.rb
@@ -55,6 +55,7 @@ end
 to_field 'language_material_ssm', extract_xpath('./did/langmaterial')
 to_field 'language_ssim', extract_xpath('./did/langmaterial/language')
 
+# Preserve HTML tags in the title
 to_field 'title_html_ssm', extract_xpath('./did/unittitle', to_text: false)
 
 to_field 'normalized_title_html_ssm'  do |_record, accumulator, context|

--- a/lib/ead/traject/ead2_component_config.rb
+++ b/lib/ead/traject/ead2_component_config.rb
@@ -55,11 +55,10 @@ end
 to_field 'language_material_ssm', extract_xpath('./did/langmaterial')
 to_field 'language_ssim', extract_xpath('./did/langmaterial/language')
 
-# Preserve HTML tags in the title
-to_field 'title_html_ssm', extract_xpath('./did/unittitle', to_text: false)
-
-to_field 'normalized_title_html_ssm'  do |_record, accumulator, context|
-  title = context.output_hash['title_html_ssm']&.first&.to_s
+# Extract title with HTML tags preserved and normalize it
+to_field 'normalized_title_html_ssm'  do |record, accumulator, context|
+  title_elements = record.xpath('./did/unittitle')
+  title = title_elements.first&.to_s
   date = context.output_hash['normalized_date_ssm']&.first
   accumulator << settings['title_normalizer'].constantize.new(title, date).to_s
 end

--- a/lib/ead/traject/ead2_config.rb
+++ b/lib/ead/traject/ead2_config.rb
@@ -108,6 +108,7 @@ end
 
 @index_steps.delete_if { |index_step| index_step.is_a?(ToFieldStep) && ['date_range_isim'].include?(index_step.field_name) }
 
+# Preserve HTML tags in the title
 to_field 'title_html_ssm', extract_xpath('/ead/archdesc/did/unittitle', to_text: false)
 
 to_field 'normalized_title_html_ssm' do |_record, accumulator, context|

--- a/lib/ead/traject/ead2_config.rb
+++ b/lib/ead/traject/ead2_config.rb
@@ -108,11 +108,10 @@ end
 
 @index_steps.delete_if { |index_step| index_step.is_a?(ToFieldStep) && ['date_range_isim'].include?(index_step.field_name) }
 
-# Preserve HTML tags in the title
-to_field 'title_html_ssm', extract_xpath('/ead/archdesc/did/unittitle', to_text: false)
-
-to_field 'normalized_title_html_ssm' do |_record, accumulator, context|
-  title = context.output_hash['title_html_ssm']&.first&.to_s
+# Extract title with HTML tags preserved and normalize it
+to_field 'normalized_title_html_ssm' do |record, accumulator, context|
+  title_elements = record.xpath('/ead/archdesc/did/unittitle')
+  title = title_elements.first&.to_s
   dates = context.output_hash['normalized_date_ssm']&.first
   accumulator << Arclight::NormalizedTitle.new(title, dates).to_s
 end

--- a/lib/ead/traject/ead2_config.rb
+++ b/lib/ead/traject/ead2_config.rb
@@ -108,6 +108,13 @@ end
 
 @index_steps.delete_if { |index_step| index_step.is_a?(ToFieldStep) && ['date_range_isim'].include?(index_step.field_name) }
 
+to_field 'title_html_ssm', extract_xpath('/ead/archdesc/did/unittitle', to_text: false)
+
+to_field 'normalized_title_html_ssm' do |_record, accumulator, context|
+  title = context.output_hash['title_html_ssm']&.first&.to_s
+  dates = context.output_hash['normalized_date_ssm']&.first
+  accumulator << Arclight::NormalizedTitle.new(title, dates).to_s
+end
 
 to_field 'date_range_isim', extract_xpath('/ead/archdesc/did/unitdate/@normal', to_text: false) do |_record, accumulator|
   range = Arclight::YearRange.new

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -52,8 +52,36 @@ describe SolrDocument, type: :model do
     })
   end
 
+  describe "#normalized_title" do
+    context "when the title contains both italicized and non-italicized sections" do
+      let(:solr_doc_with_html_title) do
+        described_class.new({
+          'normalized_title_html_ssm' => '<unittitle><title render="italic">Administrative</title> files, 1979-1997</unittitle>' ,
+        })
+      end
+
+      it 'transforms italic parts to em tags and preserves non-italic text and date' do
+        result = solr_doc_with_html_title.normalized_title
+        expect(result).to eq('<em>Administrative</em> files, 1979-1997')
+      end
+    end
+
+    context "when the title has no render attribute" do
+      let(:solr_doc_with_plain_title) do
+        described_class.new({
+          'normalized_title_html_ssm' => '<unittitle><title>Administrative files</title>, 1979-1997</unittitle>',
+        })
+      end
+
+      it 'returns the title with span tags and date preserved' do
+        result = solr_doc_with_plain_title.normalized_title
+        expect(result).to eq('<span>Administrative files</span>, 1979-1997')
+      end
+    end
+  end
+
   describe '#requestable?' do
-    it  "returns true when the solr_document's repository allows requests, and the record has a parent container, "\
+    it "returns true when the solr_document's repository allows requests, and the record has a parent container, "\
         "and the record is not otherwise marked as unavailable" do
       expect(solr_doc.requestable?).to eq(true)
     end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -56,7 +56,7 @@ describe SolrDocument, type: :model do
     context "when the title contains both italicized and non-italicized sections" do
       let(:solr_doc_with_html_title) do
         described_class.new({
-          'normalized_title_html_ssm' => '<unittitle><title render="italic">Administrative</title> files, 1979-1997</unittitle>' ,
+          'normalized_title_html_ssm' => '<unittitle><title render="italic">Administrative</title> files, 1979-1997</unittitle>'
         })
       end
 
@@ -69,7 +69,7 @@ describe SolrDocument, type: :model do
     context "when the title has no render attribute" do
       let(:solr_doc_with_plain_title) do
         described_class.new({
-          'normalized_title_html_ssm' => '<unittitle><title>Administrative files</title>, 1979-1997</unittitle>',
+          'normalized_title_html_ssm' => '<unittitle><title>Administrative files</title>, 1979-1997</unittitle>'
         })
       end
 


### PR DESCRIPTION
# Ticket [ACFA-630](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-630)

Enables HTML formatting specified in the `render` attribute for documents that contain `<title>` within `<unittitle>`.
```
<unittitle>
  <title render="italic">Series I: TRIGA reactor records</title>
</unittitle>
```

The changes are mainly based on Duke University's implementation mentioned [here](https://github.com/projectblacklight/arclight/issues/1511#issuecomment-2877800518)!

<img width="1339" height="1084" alt="Screenshot 2025-08-07 at 2 29 10 PM" src="https://github.com/user-attachments/assets/d9a7bcb0-50eb-49ec-aacc-9094b793bdf0" />
