### PR TITLE
ACFA-636 Display bibliography elements

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -253,6 +253,7 @@ class CatalogController < ApplicationController
     config.add_summary_field 'abstract', field: 'abstract_html_tesm', helper_method: :render_html_tags
     config.add_summary_field 'extent', field: 'extent_ssm'
     config.add_summary_field 'language', field: 'language_material_ssm'
+    config.add_summary_field 'bibliography', field: 'bibliography_html_tesim', helper_method: :render_html_tags
     config.add_summary_field 'scopecontent', field: 'scopecontent_html_tesm', helper_method: :render_html_tags
     config.add_summary_field 'bioghist', field: 'bioghist_html_tesm', helper_method: :render_html_tags
 
@@ -313,6 +314,7 @@ class CatalogController < ApplicationController
     config.add_component_field 'extent', field: 'extent_ssm'
     config.add_component_field 'altformavail', field: 'altformavail_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'scopecontent', field: 'scopecontent_html_tesm', helper_method: :render_html_tags
+    config.add_component_field 'bibliography', field: 'bibliography_html_tesim', helper_method: :render_html_tags
     config.add_component_field 'bioghist', field: 'bioghist_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'acqinfo', field: 'acqinfo_ssim', helper_method: :render_html_tags
     config.add_component_field 'phystech', field: 'phystech_html_tesm', helper_method: :render_html_tags

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -117,6 +117,7 @@ en:
         physfacet: Physical facet
         physloc: Physical location
         descrules: Rules or conventions
+        bibliography: Bibliography
         odd: Other information
         dimensions: Dimensions
         callnumber: Local call number

--- a/lib/ead/traject/ead2_component_config.rb
+++ b/lib/ead/traject/ead2_component_config.rb
@@ -26,8 +26,12 @@ end
 
 to_field 'bibliography_html_tesim' do |record, accumulator|
   record.xpath('.//bibliography').each do |bib_node|
-    processed_bib = process_bibliography_element(bib_node)
-    accumulator << processed_bib
+    # Extract only content elements (excluding <head>)
+    content_elements = bib_node.xpath('./*[not(self::head)]')
+    next if content_elements.empty?
+
+    processed_content = process_bibliography_content(content_elements)
+    accumulator << processed_content
   end
 end
 

--- a/lib/ead/traject/ead2_component_config.rb
+++ b/lib/ead/traject/ead2_component_config.rb
@@ -24,6 +24,13 @@ to_field 'repository_id_ssi' do |record, accumulator, context|
   end
 end
 
+to_field 'bibliography_html_tesim' do |record, accumulator|
+  record.xpath('.//bibliography').each do |bib_node|
+    processed_bib = process_bibliography_element(bib_node)
+    accumulator << processed_bib
+  end
+end
+
 @index_steps.delete_if { |index_step| index_step.is_a?(ToFieldStep) && ['date_range_isim'].include?(index_step.field_name) }
 
 to_field 'date_range_isim', extract_xpath('./did/unitdate/@normal', to_text: false) do |_record, accumulator|

--- a/lib/ead/traject/ead2_config.rb
+++ b/lib/ead/traject/ead2_config.rb
@@ -108,8 +108,12 @@ end
 
 to_field 'bibliography_html_tesim' do |record, accumulator|
   record.xpath('/ead/archdesc/bibliography').each do |bib_node|
-    processed_bib = process_bibliography_element(bib_node)
-    accumulator << processed_bib
+    # Extract only content elements (excluding <head>)
+    content_elements = bib_node.xpath('./*[not(self::head)]')
+    next if content_elements.empty?
+
+    processed_content = process_bibliography_content(content_elements)
+    accumulator << processed_content
   end
 end
 

--- a/lib/ead/traject/ead2_config.rb
+++ b/lib/ead/traject/ead2_config.rb
@@ -106,6 +106,13 @@ to_field 'repository_id_ssi' do |record, accumulator, context|
   accumulator.concat([context.clipboard[:repository_id]])
 end
 
+to_field 'bibliography_html_tesim' do |record, accumulator|
+  record.xpath('/ead/archdesc/bibliography').each do |bib_node|
+    processed_bib = process_bibliography_element(bib_node)
+    accumulator << processed_bib
+  end
+end
+
 @index_steps.delete_if { |index_step| index_step.is_a?(ToFieldStep) && ['date_range_isim'].include?(index_step.field_name) }
 
 

--- a/lib/ead/traject/ead2_shared.rb
+++ b/lib/ead/traject/ead2_shared.rb
@@ -9,3 +9,14 @@ def extents_per_physdesc(physdescs_nodes)
     extents.join(' ')
   end
 end
+
+# Replace bibref tags with paragraph tags to add spacing between elements
+def process_bibliography_element(bib_node)
+  bib_string = bib_node.to_s
+
+  # Replace <bibref> with <p> and </bibref> with </p>
+  bib_string.gsub!(/<bibref([^>]*)>/, '<p\1>')
+  bib_string.gsub!(/<\/bibref>/, '</p>')
+
+  bib_string
+end

--- a/lib/ead/traject/ead2_shared.rb
+++ b/lib/ead/traject/ead2_shared.rb
@@ -11,12 +11,14 @@ def extents_per_physdesc(physdescs_nodes)
 end
 
 # Replace bibref tags with paragraph tags to add spacing between elements
-def process_bibliography_element(bib_node)
-  bib_string = bib_node.to_s
+def process_bibliography_content(content_elements)
+  content_elements.map do |element|
+    element_string = element.to_s
 
-  # Replace <bibref> with <p> and </bibref> with </p>
-  bib_string.gsub!(/<bibref([^>]*)>/, '<p\1>')
-  bib_string.gsub!(/<\/bibref>/, '</p>')
+    # Replace <bibref> with <p> and </bibref> with </p>
+    element_string.gsub!(/<bibref([^>]*)>/, '<p\1>')
+    element_string.gsub!(/<\/bibref>/, '</p>')
 
-  bib_string
+    element_string
+  end.join("\n")
 end

--- a/spec/ead/traject/ead2_config_spec.rb
+++ b/spec/ead/traject/ead2_config_spec.rb
@@ -330,4 +330,28 @@ describe Traject::Indexer do
         end
       end
     end
+
+  describe 'bibliography indexing' do
+    let(:fixture_path) { File.join(file_fixture_path, 'ead/test_ead.xml') }
+
+    it 'excludes head elements from bibliography content' do
+      bibliography_content = index_document[:bibliography_html_tesim].join(' ')
+      expect(bibliography_content).not_to include('Publications About Described Materials')
+      expect(bibliography_content).not_to include('Publications based on the collection')
+    end
+
+    it 'includes paragraph content from first bibliography' do
+      first_bibliography = index_document[:bibliography_html_tesim][0]
+      expect(first_bibliography).to include('Cosenza, Mario Emilio. Dictionary of the Italian Humanists.')
+      expect(first_bibliography).to include('Anonymous. The title is missing.')
+    end
+
+    it 'converts bibref elements to paragraph tags in second bibliography' do
+      second_bibliography = index_document[:bibliography_html_tesim][1]
+      expect(second_bibliography).to include('<p>')
+      expect(second_bibliography).to include('</p>')
+      expect(second_bibliography).not_to include('<bibref>')
+      expect(second_bibliography).not_to include('</bibref>')
+    end
+  end
 end


### PR DESCRIPTION
# Ticket [ACFA-636](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-636)

## Overview
Displays the content of `<bibliography>` tags in collections and components.

## Structure
Since bibliography tags can get quite complex, we've focused on how they’re used in our EAD files.

Possible scenarios include:
1. Multiple bibliography elements displayed together
2. Bibliography elements that contain child `<p>` elements
3. Bibliography elements with child `<bibref>` tags
4. Bibliography elements containing both `<p>` and `<bibref>` elements

To improve readability, paragraphs are used to separate multiple bibref elements, which would otherwise appear without spacing. Head elements were also removed from the UI.

Example bibliography:
```
<bibliography id="aspace_identifier_123456789">
    <head>Bibliography</head>
    <p>Test content item 1 Test content item 2</p>
    <bibref>Test item 1</bibref>
    <bibref>Test item 2</bibref>
</bibliography>
```

<img width="893" height="1137" alt="bibliography-example" src="https://github.com/user-attachments/assets/43736390-e0c8-40f8-a282-81c42b58bd41" />

