### PR TITLE
Update nokogiri to 1.18.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'marc'
 gem 'iso-639'
 
-gem 'nokogiri', '~> 1.17.0'
+gem 'nokogiri', '~> 1.18', '>= 1.18.9', force_ruby_platform: true
 gem 'loofah', '~> 2.19.1'
 
 gem 'arclight', '~> 1.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,7 +271,7 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.4)
-    nokogiri (1.17.2)
+    nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     omniauth (2.1.2)
@@ -510,7 +510,7 @@ DEPENDENCIES
   loofah (~> 2.19.1)
   marc
   mysql2
-  nokogiri (~> 1.17.0)
+  nokogiri (~> 1.18, >= 1.18.9)
   omniauth (~> 2.1)
   omniauth-cul (~> 0.2.0)
   puma (~> 6.6.0)
@@ -539,4 +539,4 @@ RUBY VERSION
    ruby 3.1.3p185
 
 BUNDLED WITH
-   2.3.9
+   2.6.9


### PR DESCRIPTION
Now installing nokogiri using the force_ruby_platform option to get around a GLIBC dependency issue on the server.  Also updated bundler version to support the force_ruby_platform option.