### PR TITLE
ACFA-637 Fix rollup security alert - remove vite-plugin-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "globals": "^15.0.0",
     "vite": "^5.4.19",
-    "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-ruby": "^5.1.0"
   },
   "dependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,25 @@
 import { defineConfig } from 'vite';
 import RubyPlugin from 'vite-plugin-ruby';
-import eslint from 'vite-plugin-eslint';
 import basicSsl from '@vitejs/plugin-basic-ssl';
+
+const eslintPlugin = () => {
+  return {
+    name: 'vite:eslint',
+    async buildStart() {
+      const { ESLint } = await import('eslint');
+      const eslint = new ESLint();
+      const results = await eslint.lintFiles(['app/javascript/**/*.{js,jsx,ts,tsx}']);
+
+      await ESLint.outputFixes(results);
+
+      const formatter = await eslint.loadFormatter('stylish');
+      const resultText = formatter.format(results);
+      if (resultText) {
+        console.log(resultText);
+      }
+    }
+  };
+};
 
 export default defineConfig({
   plugins: [
@@ -9,6 +27,6 @@ export default defineConfig({
     // cert when the server is running under https.
     basicSsl({}),
     RubyPlugin(),
-    eslint(),
+    eslintPlugin(),
   ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,14 +873,6 @@
     uncontrollable "^8.0.1"
     warning "^4.0.3"
 
-"@rollup/pluginutils@^4.2.1":
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz"
-  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
-  dependencies:
-    estree-walker "^2.0.1"
-    picomatch "^2.2.2"
-
 "@rollup/rollup-android-arm-eabi@4.40.0":
   version "4.40.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.0.tgz#d964ee8ce4d18acf9358f96adc408689b6e27fe3"
@@ -988,28 +980,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@types/eslint@^8.4.5":
-  version "8.56.9"
-  resolved "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.9.tgz"
-  integrity sha512-W4W3KcqzjJ0sHg2vAq9vfml6OhsJ53TcUjUqfzzZf/EChUtwspszj/S0pzMxnfRcO55/iGq47dscXw71Fxc4Zg==
-  dependencies:
-    "@types/estree" "*"
-    "@types/json-schema" "*"
-
-"@types/estree@*":
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz"
-  integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
-
 "@types/estree@1.0.7":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
   integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
-
-"@types/json-schema@*":
-  version "7.0.15"
-  resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
-  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -1990,11 +1964,6 @@ estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
-
-estree-walker@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz"
-  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -3093,7 +3062,7 @@ picocolors@^1.0.0, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.2.2, picomatch@^2.3.1:
+picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -3500,13 +3469,6 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
-
-rollup@^2.77.2:
-  version "2.79.1"
-  resolved "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz"
-  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
-  optionalDependencies:
-    fsevents "~2.3.2"
 
 rollup@^4.20.0:
   version "4.40.0"
@@ -4030,15 +3992,6 @@ videojs-vtt.js@^0.15.5:
   integrity sha512-yZbBxvA7QMYn15Lr/ZfhhLPrNpI/RmCSCqgIff57GC2gIrV5YfyzLfLyZMj0NnZSAz8syB4N0nHXpZg9MyrMOQ==
   dependencies:
     global "^4.3.1"
-
-vite-plugin-eslint@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.npmjs.org/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz"
-  integrity sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==
-  dependencies:
-    "@rollup/pluginutils" "^4.2.1"
-    "@types/eslint" "^8.4.5"
-    rollup "^2.77.2"
 
 vite-plugin-ruby@^5.1.0:
   version "5.1.1"


### PR DESCRIPTION
# Part of [ACFA-637](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-637)

Addresses the [DOM Clobbering Gadget found in rollup bundled scripts that leads to XSS](https://github.com/cul/ldpd-findingaids-asi/security/dependabot/128) alert.

Resolution: 
Removes the `vite-plugin-eslint` package that uses up rollup 2.79.1. The earliest patched version of rollup for this package is 2.79.2 (Vite is already using rollup 4.20.0).

This package hasn't been updated in 3 years. Considering that Vite comes with Eslint natively, we don't really need this package. To replicate showing Eslint errors at runtime, I added `eslintPlugin` method, example output below:

<img width="836" height="72" alt="Screenshot 2025-08-22 at 1 39 56 PM" src="https://github.com/user-attachments/assets/1eb895cd-25b0-4f82-9298-2d1f85af18c3" />
