### PR TITLE
Add finding_aids.yml default_search_mode configuration for switching between standard and vector default search behavior

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -54,8 +54,8 @@ class SearchBuilder < Blacklight::SearchBuilder
     end
 
     # Vector embedding service returned embedding data.  Replace query with vector version.
-    # solr_parameters[:q] = "{!knn f=scopecontent_vector768i topK=9999}[#{query_vector.join(', ')}]"
-    solr_parameters[:q] = "{!vectorSimilarity f=scopecontent_vector768i minReturn=0.79}[#{query_vector.join(', ')}]"
+    # solr_parameters[:q] = "{!knn f=searchable_text_vector768i topK=9999}[#{query_vector.join(', ')}]"
+    solr_parameters[:q] = "{!vectorSimilarity f=searchable_text_vector768i minReturn=0.79}[#{query_vector.join(', ')}]"
   end
 
   def vector_search_enabled?

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+# NOTE: This class is NOT automatically reloaded when doing local development,
+# so you'll need to restart your Rails server whenever you make changes.
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include BlacklightRangeLimit::RangeLimitBuilder
@@ -52,7 +55,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
     # Vector embedding service returned embedding data.  Replace query with vector version.
     # solr_parameters[:q] = "{!knn f=scopecontent_vector768i topK=9999}[#{query_vector.join(', ')}]"
-    solr_parameters[:q] = "{!vectorSimilarity f=scopecontent_vector768i minReturn=0.7}[#{query_vector.join(', ')}]"
+    solr_parameters[:q] = "{!vectorSimilarity f=scopecontent_vector768i minReturn=0.79}[#{query_vector.join(', ')}]"
   end
 
   def vector_search_enabled?
@@ -61,5 +64,5 @@ class SearchBuilder < Blacklight::SearchBuilder
      return vector_search_override == 'true' if %w[true false].include?(vector_search_override)
 
     CONFIG[:default_search_mode] == 'vector'
-    end
+  end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -35,12 +35,12 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def convert_query_to_embedding_for_vector_search(solr_parameters)
+    return unless vector_search_enabled? && blacklight_params[:q].present?
+
     default_search_handler = 'select'
     vector_search_handler = 'select-vector'
 
-    vector_seach_enabled = blacklight_params[:vector_search] == 'true' && blacklight_params[:q].present?
-    blacklight_config.solr_path = vector_seach_enabled ? vector_search_handler : default_search_handler
-    return unless vector_seach_enabled
+    blacklight_config.solr_path = vector_search_handler
 
     query_text = blacklight_params[:q]
     query_vector = EmbeddingService::Embedder.convert_text_to_vector_embedding(query_text)
@@ -54,4 +54,12 @@ class SearchBuilder < Blacklight::SearchBuilder
     # solr_parameters[:q] = "{!knn f=scopecontent_vector768i topK=9999}[#{query_vector.join(', ')}]"
     solr_parameters[:q] = "{!vectorSimilarity f=scopecontent_vector768i minReturn=0.7}[#{query_vector.join(', ')}]"
   end
+
+  def vector_search_enabled?
+    vector_search_override = blacklight_params[:vector_search]
+
+     return vector_search_override == 'true' if %w[true false].include?(vector_search_override)
+
+    CONFIG[:default_search_mode] == 'vector'
+    end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -59,10 +59,8 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def vector_search_enabled?
-    vector_search_override = blacklight_params[:vector_search]
-
-     return vector_search_override == 'true' if %w[true false].include?(vector_search_override)
-
+    return false if blacklight_params[:vector_search] == 'false'
+    return true if blacklight_params[:vector_search] == 'true'
     CONFIG[:default_search_mode] == 'vector'
   end
 end

--- a/config/templates/finding_aids.template.yml
+++ b/config/templates/finding_aids.template.yml
@@ -27,6 +27,8 @@ development: &DEV
   cache_html: false
   mirador_base_url: https://dlc-staging.library.columbia.edu
   embedding_service_base_url: http://localhost:9292
+  #search mode options are 'standard' or 'vector'
+  default_search_mode: 'standard'
 test:
   <<: *DEV
   ead_cache_dir: <%= Rails.root.join('test/fixtures/files/ead') %>

--- a/lib/ead/traject/ead2_component_config.rb
+++ b/lib/ead/traject/ead2_component_config.rb
@@ -161,7 +161,7 @@ to_field 'has_online_content_ssim', extract_xpath('.//dao|.//daogrp') do |_recor
   accumulator.replace([accumulator.any?])
 end
 
-to_field 'scopecontent_vector768i' do |record, accumulator, context|
+to_field 'searchable_text_vector768i' do |record, accumulator, context|
   value = semantic_search_source_text(context)
   if value.present?
     embedding = EmbeddingService::Embedder.convert_text_to_vector_embedding(value)

--- a/lib/ead/traject/ead2_config.rb
+++ b/lib/ead/traject/ead2_config.rb
@@ -193,7 +193,7 @@ to_field 'online_item_count_is', first_only do |record, accumulator|
   accumulator << record.xpath('.//dao|.//daogrp').count
 end
 
-to_field 'scopecontent_vector768i' do |record, accumulator, context|
+to_field 'searchable_text_vector768i' do |record, accumulator, context|
   value = semantic_search_source_text(context)
   if value.present?
     embedding = EmbeddingService::Embedder.convert_text_to_vector_embedding(value)


### PR DESCRIPTION
# Ticket [ACFA-645](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-645)

Adds the ability to make the Finding Aids app search default to either standard or vector search while also responding to a vector_search_override parameter.

