### PR TITLE
ACFA-682: Display repository name instead of the slug on repo search pages

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module CatalogHelper
+  include Blacklight::CatalogHelperBehavior
+
+  # Override Blacklight's render_search_to_page_title_filter to fix an issue where
+  # facet_configuration_for_field fails to find the config when the Blacklight
+  # facet key (e.g. 'repository') differs from the Solr field name (e.g.
+  # 'repository_id_ssi'). This causes helper_method (like :repository_label)
+  # to be ignored in the page <title>, showing repository slugs instead of full names.
+  def render_search_to_page_title_filter(facet, values)
+    facet_config = blacklight_config.facet_fields[facet] || facet_configuration_for_field(facet)
+    filter_label = facet_field_label(facet_config.key)
+    filter_value = if values.size < 3
+                     values.map { |value| facet_item_presenter(facet_config, value, facet).label }.to_sentence
+                   else
+                     t('blacklight.search.page_title.many_constraint_values', values: values.size)
+                   end
+    t('blacklight.search.page_title.constraint', label: filter_label, value: filter_value)
+  end
+end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe CatalogHelper, type: :helper do
+  include ControllerLevelHelpers
+
+  describe '#render_search_to_page_title_filter' do
+    let(:blacklight_config) { CatalogController.blacklight_config }
+
+    before do
+      initialize_controller_helpers(helper)
+      allow(helper).to receive(:blacklight_config).and_return(blacklight_config)
+    end
+
+    context 'when facet key differs from Solr field name' do
+      it 'uses the helper_method to render the repository name instead of the slug' do
+        # The 'repository' facet key maps to Solr field 'repository_id_ssi'
+        # and has helper_method: :repository_label
+        result = helper.render_search_to_page_title_filter('repository', ['nnc-a'])
+        expect(result).to include('Avery Drawings & Archives Collections')
+        expect(result).not_to include('nnc-a')
+      end
+    end
+
+    context 'when facet key matches Solr field name' do
+      it 'still works normally for standard facets' do
+        result = helper.render_search_to_page_title_filter('level', ['Collection'])
+        expect(result).to include('Collection')
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket [ACFA-682](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-682)

## Overview
Changes the page title for repository search pages to contain repository name (e.g. "Repository: Rare Book & Manuscript Library") instead of the repository slug (e.g. "Repository: nnc-rb").

## Details
When Blacklight builds the page `<title>` for a search results page, it calls `render_search_to_page_title_filter` for each active facet filter. That method calls `facet_configuration_for_field` to retrieve the facet config, which is what allows the `repository_label` to be passed along, the helper responsible for translating repository slugs into full names. Without the correct config, `repository_label` is never invoked and the slug appears in the `<title>` instead.

The problem is in Blacklight's `facet_configuration_for_field` ([link](https://github.com/projectblacklight/blacklight/blob/v8.7.0/lib/blacklight/configuration.rb#L431-L438)) - it silently discards a found config when the Blacklight facet key differs from the Solr field name. Our repository facet has `key: 'repository'` and `field: 'repository_id_ssi'`, so the lookup returns nothing.

The fix is to override `render_search_to_page_title_filter` with a one-line change to try the key-based lookup first, then fall back to the original:

From
```rb
facet_config = facet_configuration_for_field(facet)
```

To
```rb
facet_config = blacklight_config.facet_fields[facet] || facet_configuration_for_field(facet)
```