### PR TITLE
ACFA-696: Fix component-level subject terms link

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -338,7 +338,7 @@ class CatalogController < ApplicationController
 
 
     # Component Show Page - Indexed Terms Section
-    config.add_component_indexed_terms_field 'access_subjects', field: 'access_subjects_ssim', link_to_facet: true, separator_options: {
+    config.add_component_indexed_terms_field 'subjects', field: 'access_subjects_ssim', link_to_facet: true, separator_options: {
       words_connector: '<br/>',
       two_words_connector: '<br/>',
       last_word_connector: '<br/>'


### PR DESCRIPTION
# Ticket [ACFA-696](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-696)

_Note: This PR is currently deployed to the dev environment._

The component-level subjects link used the incorrect field key "access_subjects"; updating it to "subjects" ensures that Blacklight builds the correct search query.

<img width="1011" height="758" alt="subjects-link-fix" src="https://github.com/user-attachments/assets/754a7bc8-730e-4048-a410-7d0db1f5fccc" />