### PR TITLE
ACFA-694: Determine Aeon location based on the presence of barcode

### DIFF
--- a/app/values/aeon_local_request.rb
+++ b/app/values/aeon_local_request.rb
@@ -101,7 +101,7 @@ class AeonLocalRequest
   end
 
   def location
-    @solr_document['collection_offsite_ssi'] == 'true' ? 'Offsite' : self.repository_config&.name
+    @location ||= barcode.present? ? 'Offsite' : self.repository_config&.name
   end
 
   def form_attributes

--- a/lib/ead/traject/ead2_component_config.rb
+++ b/lib/ead/traject/ead2_component_config.rb
@@ -134,11 +134,6 @@ to_field "aeon_unprocessed_ssi", extract_xpath("/ead/archdesc/accessrestrict") d
   accumulator.replace([accumulator.map {|value| value.match(unprocessed_regex) }.any?])
 end
 
-to_field "collection_offsite_ssi", extract_xpath("/ead/archdesc/accessrestrict") do |_record, accumulator|
-  offsite_regex = /off[\s-]?site/i
-  accumulator.replace([accumulator.map {|value| value.match(offsite_regex) }.any?])
-end
-
 to_field "aeon_unavailable_for_request_ssi", extract_xpath("./accessrestrict/p") do |_record, accumulator|
   unavailable_for_request = /restricted|closed|missing/i
   accumulator.replace([accumulator.map {|value| value.match(unavailable_for_request) }.any?])

--- a/spec/ead/traject/ead2_config_spec.rb
+++ b/spec/ead/traject/ead2_config_spec.rb
@@ -198,37 +198,6 @@ describe Traject::Indexer do
     end
   end
 
-  describe 'offsite collection access note indexing' do
-    let(:fixture_path) { File.join(file_fixture_path, 'ead/test_ead.xml') }
-    let(:fixture_file_data) do
-      File.read(fixture_path).gsub('This collection is PLACEHOLDER_O.F.F.S.I.T.E_STATUS.', "This collection is #{keyword}.")
-    end
-    context 'when the offsite keyword is not present' do
-      let(:keyword) { 'onsite' }
-      it do
-        expect(index_document[:components][0][:collection_offsite_ssi]).to eq([false])
-      end
-    end
-    context 'when the "offsite" keyword is present' do
-      let(:keyword) { 'offsite' }
-      it do
-        expect(index_document[:components][0][:collection_offsite_ssi]).to eq([true])
-      end
-    end
-    context 'when the "off-site" keyword is present' do
-      let(:keyword) { 'off-site' }
-      it do
-        expect(index_document[:components][0][:collection_offsite_ssi]).to eq([true])
-      end
-    end
-    context 'when the "off site" keyword is present' do
-      let(:keyword) { 'off site' }
-      it do
-        expect(index_document[:components][0][:collection_offsite_ssi]).to eq([true])
-      end
-    end
-  end
-
   describe 'restricted/closed/missing access note indexing' do
     let(:fixture_path) { File.join(file_fixture_path, 'ead/test_ead.xml') }
     let(:fixture_file_data) do
@@ -237,7 +206,6 @@ describe Traject::Indexer do
     context 'when restricted/closed/missing keywords are not present' do
       let(:keyword) { 'open' }
       it do
-        # expect(index_document[:components][0][:components][0][:components][0][:aeon_unavailable_for_request_ssi]).to eq([false])
         expect(index_document[:components][0][:components][0][:aeon_unavailable_for_request_ssi]).to eq([false])
       end
     end

--- a/spec/values/aeon_local_request_spec.rb
+++ b/spec/values/aeon_local_request_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe AeonLocalRequest do
   let(:folder_label) { 'folder 1 to 3' }
   let(:parent_unittitles_ssm) { ['First value', 'Series 2'] }
   let(:call_number) { 'MS#1234' }
-  let(:collection_offsite_ssi) { 'false' }
   let(:digital_objects_ssm) { nil }
   let(:container_information_ssm) do
     [
@@ -43,7 +42,6 @@ RSpec.describe AeonLocalRequest do
       'container_information_ssm' => container_information_ssm,
       'parent_unittitles_ssm' => parent_unittitles_ssm,
       'call_number_ss' => call_number,
-      'collection_offsite_ssi' => collection_offsite_ssi,
       'digital_objects_ssm' => digital_objects_ssm
     })
   end
@@ -309,14 +307,14 @@ RSpec.describe AeonLocalRequest do
 
   describe '#location' do
     context 'an item from an onsite collection' do
-      let(:collection_offsite_ssi) { 'false' }
+      let(:barcode) { nil }
       it 'returns the expected value' do
         expect(aeon_local_request.location).to eq('Rare Book & Manuscript Library')
       end
     end
 
     context 'an item from an offsite collection' do
-      let(:collection_offsite_ssi) { 'true' }
+      let(:barcode) { 'barcode123'}
       it 'returns the expected value' do
         expect(aeon_local_request.location).to eq('Offsite')
       end
@@ -345,7 +343,7 @@ RSpec.describe AeonLocalRequest do
         'ItemNumber' => 'RH00002380',
         'ItemSubTitle' => title_ssm.first,
         'CallNumber' => 'MS#1234',
-        'Location' => 'Rare Book & Manuscript Library',
+        'Location' => 'Offsite',
         'Transaction.CustomFields.TopContainerID' => '/repositories/2/top_containers/145199',
       }
     end


### PR DESCRIPTION
# Ticket [ACFA-694](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-694)

**Do not merge; this work depends on [FOLIOSYNC-18](https://columbiauniversitylibraries.atlassian.net/browse/FOLIOSYNC-18).**

This PR modifies the logic for determining whether an item’s location is "Offsite" to use the presence of a barcode (items with barcodes are located offsite). We also no longer need to store `collection_offsite_ssi`, as it was used only to construct the data sent to Aeon.

Example Aeon request for 2 items: the first item doesn’t have a barcode, and the second does.
<img width="594" height="669" alt="aeon_location_update" src="https://github.com/user-attachments/assets/5a74b982-b1ea-454b-86d6-08e75b3f1f6d" />
