### PR TITLE
ACFA-698: Expunge "Deleted Docs" causing zombie titles in the suggester

### DIFF
--- a/lib/acfa/index.rb
+++ b/lib/acfa/index.rb
@@ -1,5 +1,13 @@
 module Acfa::Index
   def self.build_suggester(solr_url)
-    `curl #{solr_url}suggest?suggest.build=true`
+    # Expunge deletes to clear out any "Deleted Docs" from the index. We have observed that 
+    # "Deleted Docs" are read during a suggest dictionary rebuild, and we do not want 
+    # to add stale data to the suggester dictionaries.
+    # Expunge deletes all "Deleted Docs" only if Solr is configured with a merge policy that sets forceMergeDeletesPctAllowed to 0.0. 
+    # If not set, forceMergeDeletesPctAllowed defaults to 10.0, meaning segments with 10% or fewer deleted documents will not be merged, 
+    # causing Deleted Docs to not be completely expunged.
+    `curl #{solr_url}update?commit=true&expungeDeletes=true`
+    # Rebuild all suggester dictionaries
+    `curl #{solr_url}suggest?suggest.buildAll=true`
   end
 end

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -129,6 +129,14 @@ limitations under the License.
         </mergePolicyFactory>
       -->
 
+    <mergePolicyFactory class="org.apache.solr.index.TieredMergePolicyFactory">
+      <int name="maxMergeAtOnce">10</int>
+      <int name="segmentsPerTier">10</int>
+      <int name="targetSearchConcurrency">1</int>
+      <double name="forceMergeDeletesPctAllowed">0.0</double>
+      <double name="deletesPctAllowed">33.0</double>
+    </mergePolicyFactory>
+
     <!-- Expert: Merge Scheduler
         The Merge Scheduler in Lucene controls how merges are
         performed.  The ConcurrentMergeScheduler (Lucene 2.3 default)

--- a/spec/acfa/index_spec.rb
+++ b/spec/acfa/index_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Acfa::Index do
   describe ".build_suggester" do
     let(:example_solr_url) { 'https://example.com:12345' }
     it "works as expected" do
-      expect(described_class).to receive(:`).with("curl #{example_solr_url}suggest?suggest.build=true")
+      expect(described_class).to receive(:`).with("curl #{example_solr_url}update?commit=true&expungeDeletes=true")
+      expect(described_class).to receive(:`).with("curl #{example_solr_url}suggest?suggest.buildAll=true")
       described_class.build_suggester(example_solr_url)
     end
   end


### PR DESCRIPTION
# Ticket [ACFA-698](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-698)

## Overview
This PR fixes an issue where the autosuggester displays both the new and the old title for records that were updated and successfully reindexed.

## Details
When updating a record with a new title, the nightly cron job successfully rebuilt the index and suggester dictionary. The `/suggest` endpoint was still holding onto the old title, while also containing the updated title. We've discovered that building the suggester also includes "Deleted Docs" (at the time when the issue was discovered, the production core contained around 300k Deleted Docs). 

#### What we tried:
- `update?commit=true&expungeDeletes=true` - this didn't expunge all "Deleted Docs" (by default, only segments with 10% or more deleted docs are merged)
- `update?optimize=true&maxSegments=1` - this successfully expunged all Deleted Docs and merged all segments into one. It also caused a memory spike in our core. However, according to the Solr documentation, condensing everything into a single segment is not recommended, so we looked for an alternative.

#### Solution:
Using `update?commit=true&expungeDeletes=true` combined with `forceMergeDeletesPctAllowed` set to 0 in solrconfig.xml allows us to expunge all deleted docs while keeping the segments above 1. This operation also doesn’t cause a performance spike significant enough to warrant a separate cron on a reduced schedule, so I kept it in the existing `build_suggester` method, which runs daily.