### PR TITLE
ACFA-699: Send multiple top containers to Aeon

### DIFF
--- a/app/controllers/aeon_requests_controller.rb
+++ b/app/controllers/aeon_requests_controller.rb
@@ -40,7 +40,8 @@ class AeonRequestsController < ApplicationController
       rows: ids.length
     )
 
-    @aeon_requests = solr_response.dig('response', 'docs').map { |doc| SolrDocument.new(doc) }.map { |doc| doc.aeon_request }
+    # A single document can span multiple top containers, each container becomes its own Aeon request (see SolrDocument#aeon_requests).
+    @aeon_requests = solr_response.dig('response', 'docs').map { |doc| SolrDocument.new(doc) }.flat_map { |doc| doc.aeon_requests }
     @aeon_dll_url = params[:login_method] == 'shib' ? AEON[:shib_dll_url] : AEON[:non_shib_dll_url]
     @note = params[:note]
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -56,6 +56,12 @@ class SolrDocument
     @aeon_request ||= AeonLocalRequest.new(self)
   end
 
+  # We submit one AeonLocalRequest per top container, so a component that spans multiple top
+  # containers (eg. box 47 and box 50) is checked out as separate Aeon transactions
+  def aeon_requests
+    @aeon_requests ||= AeonLocalRequest.for_top_containers(self)
+  end
+
   # Override to permit indexing of more xlink attributes via Acfa::DigitalObject subclass of Arclight::DigitalObject
   def digital_objects
     digital_objects_field = fetch('digital_objects_ssm', []).reject(&:empty?)

--- a/app/values/aeon_local_request.rb
+++ b/app/values/aeon_local_request.rb
@@ -4,9 +4,24 @@
 # POST form specifically aimed at Aeon's external request
 # endpoint (https://support.atlas-sys.com/hc/en-us/articles/360011820054-External-Request-Endpoint)
 class AeonLocalRequest
-  def initialize(solr_document)
+  def initialize(solr_document, container_information: nil)
     raise ArgumentError.new("solr_document cannot be nil") if solr_document.nil?
     @solr_document = solr_document
+
+    # When given, this request covers just one top container of the document
+    # rather than the whole component
+    @container_information_override = container_information
+  end
+
+  # Returns one AeonLocalRequest per distinct top container on the document, each
+  # scoped to that top container's slice of container_information.
+  # Falls back to a single request when there is only 1 top-container group.
+  def self.for_top_containers(solr_document)
+    request = new(solr_document)
+    slices = request.container_information.group_by { |container| container['top_container_uri'] }.values
+    return [request] if slices.length <= 1
+
+    slices.map { |slice| new(solr_document, container_information: slice) }
   end
 
   def repository_config
@@ -65,7 +80,8 @@ class AeonLocalRequest
   end
 
   def container_information
-    @container_information ||= @solr_document.fetch('container_information_ssm', []).map {|info_json| JSON.parse(info_json) }
+    @container_information ||= @container_information_override ||
+      @solr_document.fetch('container_information_ssm', []).map {|info_json| JSON.parse(info_json) }
   end
 
   def barcode

--- a/lib/ead/traject/ead2_component_config.rb
+++ b/lib/ead/traject/ead2_component_config.rb
@@ -108,19 +108,32 @@ to_field "container_information_ssm" do |record, accumulator, context|
   record.xpath("./did/container").each do |container_element|
     type = container_element.attributes["type"].to_s
     container_id = container_element.attributes["id"].to_s
+    container_parent = container_element.attribute("parent").to_s
     barcode_label = container_element.attributes["label"].to_s
     barcode_match = barcode_label.match(/\[([^\]]+)\]/)
     barcode = barcode_match[1] if barcode_match
     text = [container_element.attribute("type"), container_element.text].join(" ").strip
-    
+
+    # Reference to the top container this element belongs to
+    top_container_ref = container_parent.present? ? container_parent : container_id
+
+    # Grouping key that allows a component's containers to be partitioned by top container.
+    # This is only for internal grouping and is not sent to Aeon.
+    top_container_uri =
+      if top_container_ref.start_with?("repositories")
+        "/" + top_container_ref.sub(/\.\d+$/, '').gsub('.', '/')
+      elsif top_container_ref.present?
+        top_container_ref
+      end
+
     # Convert container ID to URI path (only for boxes with repository IDs)
-    # Example: "repositories.2.top_containers.145199.1" -> "/repositories/2/top_containers/145199"
     uri = if type == "box" && container_id.start_with?("repositories")
             "/" + container_id.sub(/\.\d+$/, '').gsub('.', '/')
           end
-    
+
     container_information = {
       uri: uri,
+      top_container_uri: top_container_uri,
       barcode: barcode,
       label: text,
       type: type

--- a/spec/ead/traject/ead2_config_spec.rb
+++ b/spec/ead/traject/ead2_config_spec.rb
@@ -150,6 +150,7 @@ describe Traject::Indexer do
         {
           'barcode' => 'RH000023801',
           'uri' => '/repositories/2/top_containers/145199',
+          'top_container_uri' => '/repositories/2/top_containers/145199',
           'label' => 'box 1',
           'type' => 'box',
         }
@@ -160,10 +161,44 @@ describe Traject::Indexer do
         {
           'barcode' => nil,
           'uri' => nil,
+          'top_container_uri' => '/repositories/2/top_containers/145199',
           'label' => 'folder 1',
           'type' => 'folder'
         }
       )
+    end
+  end
+
+  describe 'top container grouping key (top_container_uri)' do
+    let(:fixture_path) { File.join(file_fixture_path, 'ead/test_multiple_top_containers.xml') }
+    let(:two_top_container_component) do
+      index_document[:components][0][:components][0][:container_information_ssm].map { |info_json| JSON.parse(info_json) }
+    end
+    let(:mapcase_component) do
+      index_document[:components][0][:components][1][:container_information_ssm].map { |info_json| JSON.parse(info_json) }
+    end
+
+    it 'partitions a two-top-container component into two distinct top_container_uri values' do
+      expect(two_top_container_component.map { |c| c['top_container_uri'] }.uniq).to eq(
+        ['/repositories/3/top_containers/143762', '/repositories/3/top_containers/155583']
+      )
+    end
+
+    it 'gives a folder the same top_container_uri as its box (derived from `parent`)' do
+      box, folder = two_top_container_component[0], two_top_container_component[1]
+      expect(box['type']).to eq('box')
+      expect(folder['type']).to eq('folder')
+      expect(folder['top_container_uri']).to eq(box['top_container_uri'])
+      expect(box['uri']).to eq('/repositories/3/top_containers/143762')
+      expect(folder['uri']).to be_nil
+    end
+
+    it 'keeps a aspace fallback key for mapcases' do
+      mapcase, folder = mapcase_component[0], mapcase_component[1]
+      expect(mapcase['type']).to eq('mapcase')
+      expect(mapcase['top_container_uri']).to eq('aspace_fb820cf9051e192c2abb6556e37266d4')
+      expect(mapcase['uri']).to be_nil
+      expect(folder['top_container_uri']).to eq('aspace_fb820cf9051e192c2abb6556e37266d4')
     end
   end
 

--- a/spec/fixtures/ead/test_multiple_top_containers.xml
+++ b/spec/fixtures/ead/test_multiple_top_containers.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd">
+  <eadheader countryencoding="iso3166-1" dateencoding="iso8601" langencoding="iso639-2b"
+    repositoryencoding="iso15511">
+    <eadid countrycode="US" mainagencycode="US-NNC-RB">123456</eadid>
+    <filedesc>
+      <titlestmt>
+        <titleproper>Multiple Top Container Test Records<num>123456</num></titleproper>
+      </titlestmt>
+      <publicationstmt>
+        <publisher>Rare Book and Manuscript Library</publisher>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>This finding aid was produced using ArchivesSpace on <date>2025-08-15</date>.</creation>
+      <langusage>Description is written in: English, Latin script.</langusage>
+    </profiledesc>
+  </eadheader>
+  <archdesc level="collection">
+    <did>
+      <repository>
+        <corpname>Rare Book and Manuscript Library</corpname>
+      </repository>
+      <unittitle>Multiple Top Container Test Records</unittitle>
+      <unitid>123456</unitid>
+      <unitid type="aspace_uri">/repositories/3/resources/7283</unitid>
+      <unitdate datechar="creation" normal="1980/2020" type="inclusive">1980-2020</unitdate>
+    </did>
+    <dsc>
+      <c id="aspace_series_1" level="series">
+        <did>
+          <unittitle>Series I</unittitle>
+          <unitid type="aspace_uri">/repositories/3/archival_objects/1</unitid>
+        </did>
+        <!-- Component that lives in two top containers (box 47 and box 50) -->
+        <c id="aspace_7adedbde8e2d2ebad7c5b6c7e251a0de" level="file">
+          <did>
+            <unittitle>Expo '86</unittitle>
+            <unitid type="aspace_uri">/repositories/3/archival_objects/1718426</unitid>
+            <unitdate datechar="creation" normal="1986/1986">1986</unitdate>
+            <container id="repositories.3.top_containers.143762.470" label="box" type="box">47</container>
+            <container id="aspace_81f256155b6dd9cd64fc625d31f02fcc"
+              parent="repositories.3.top_containers.143762.470" type="folder">12A to 12D</container>
+            <container altrender="Record storage carton"
+              id="repositories.3.top_containers.155583.471" label="box" type="box">50</container>
+            <container id="aspace_cf6de3a0bbb1eed74413dfcff1fa77de"
+              parent="repositories.3.top_containers.155583.471" type="folder">7 to 8</container>
+          </did>
+        </c>
+        <c id="aspace_mapcase_component" level="file">
+          <did>
+            <unittitle>Roof construction plan for unidentified building</unittitle>
+            <unitid type="aspace_uri">/repositories/3/archival_objects/2</unitid>
+            <unitdate datechar="creation" normal="1990/1990">1990</unitdate>
+            <container altrender="RBML mapcase" id="aspace_fb820cf9051e192c2abb6556e37266d4"
+              label="mapcase" type="mapcase">15-J-8</container>
+            <container id="aspace_a3bbbbabb9369d6ab846cfeb543a0b5d"
+              parent="aspace_fb820cf9051e192c2abb6556e37266d4" type="folder">1</container>
+          </did>
+        </c>
+      </c>
+    </dsc>
+  </archdesc>
+</ead>

--- a/spec/values/aeon_local_request_spec.rb
+++ b/spec/values/aeon_local_request_spec.rb
@@ -21,11 +21,13 @@ RSpec.describe AeonLocalRequest do
       {
         'barcode' => barcode,
         'uri' => '/repositories/2/top_containers/145199',
+        'top_container_uri' => '/repositories/2/top_containers/145199',
         'label' => box_label,
         'type' => 'box',
       }.to_json,
       {
         'barcode' => nil,
+        'top_container_uri' => '/repositories/2/top_containers/145199',
         'label' => folder_label,
         'type' => 'folder'
       }.to_json
@@ -228,6 +230,71 @@ RSpec.describe AeonLocalRequest do
       include_context "empty solr_doc"
       it 'returns a blank value' do
         expect(aeon_local_request.container_information).to be_blank
+      end
+    end
+  end
+
+  describe '.for_top_containers' do
+    def build_request_doc(containers)
+      SolrDocument.new({
+        'id' => id,
+        'collection_ssim' => collection_ssim,
+        'title_ssm' => title_ssm,
+        'normalized_date_ssm' => normalized_date_ssm,
+        'repository_id_ssi' => repository_id,
+        'call_number_ss' => call_number,
+        'collection_offsite_ssi' => collection_offsite_ssi,
+        'container_information_ssm' => containers.map(&:to_json)
+      })
+    end
+
+    let(:box_47) do
+      { 'uri' => '/repositories/3/top_containers/143762', 'top_container_uri' => '/repositories/3/top_containers/143762',
+        'barcode' => 'BC47', 'label' => 'box 47', 'type' => 'box' }
+    end
+    let(:folder_47) do
+      { 'uri' => nil, 'top_container_uri' => '/repositories/3/top_containers/143762',
+        'barcode' => nil, 'label' => 'folder 12A to 12D', 'type' => 'folder' }
+    end
+    let(:box_50) do
+      { 'uri' => '/repositories/3/top_containers/155583', 'top_container_uri' => '/repositories/3/top_containers/155583',
+        'barcode' => 'BC50', 'label' => 'box 50', 'type' => 'box' }
+    end
+    let(:folder_50) do
+      { 'uri' => nil, 'top_container_uri' => '/repositories/3/top_containers/155583',
+        'barcode' => nil, 'label' => 'folder 7 to 8', 'type' => 'folder' }
+    end
+
+    context 'a component spanning two top containers' do
+      let(:requests) { described_class.for_top_containers(build_request_doc([box_47, folder_47, box_50, folder_50])) }
+
+      it 'returns one request per top container' do
+        expect(requests.length).to eq(2)
+      end
+
+      it 'scopes ItemVolume / ItemNumber / TopContainerID to each box' do
+        first, second = requests
+        expect(first.form_attributes['ItemVolume']).to eq('box 47')
+        expect(first.form_attributes['ItemNumber']).to eq('BC47')
+        expect(first.form_attributes['Transaction.CustomFields.TopContainerID']).to eq('/repositories/3/top_containers/143762')
+
+        expect(second.form_attributes['ItemVolume']).to eq('box 50')
+        expect(second.form_attributes['ItemNumber']).to eq('BC50')
+        expect(second.form_attributes['Transaction.CustomFields.TopContainerID']).to eq('/repositories/3/top_containers/155583')
+      end
+
+      it 'gives each request a distinct grouping_field_value so the checkout view splits them' do
+        expect(requests.map(&:grouping_field_value)).to eq(['box 47', 'box 50'])
+      end
+    end
+
+    context 'a component in a single top container' do
+      let(:doc) { build_request_doc([box_47, folder_47]) }
+
+      it 'returns a single request identical to the un-split request' do
+        requests = described_class.for_top_containers(doc)
+        expect(requests.length).to eq(1)
+        expect(requests.first.form_attributes).to eq(described_class.new(doc).form_attributes)
       end
     end
   end


### PR DESCRIPTION
# Ticket [ACFA-699](https://columbiauniversitylibraries.atlassian.net/browse/ACFA-699)

## Overview
This PR changes how data is sent to Aeon by sending a separate Aeon request for each top-level container in documents with multiple top-level containers, instead of only sending a request for the first one. To accomplish this, the indexing process was updated to include a `top_container_uri` field for each item. This field is then used to correctly associate each Aeon request with the relevant `container_information` group for its top container.